### PR TITLE
TeleportLimit, Charter update

### DIFF
--- a/webwalker_logic/local/walker_engine/navigation_utils/Charter.java
+++ b/webwalker_logic/local/walker_engine/navigation_utils/Charter.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 public class Charter implements Loggable{
 
-    private static final int CHARTER_INTERFACE_MASTER = 95;
+    private static final int CHARTER_INTERFACE_MASTER = 72;
     private static Charter instance;
 
     private static Charter getInstance(){

--- a/webwalker_logic/teleport_logic/TeleportConstants.java
+++ b/webwalker_logic/teleport_logic/TeleportConstants.java
@@ -1,11 +1,28 @@
 package scripts.webwalker_logic.teleport_logic;
 
-import org.tribot.api2007.Combat;
+import org.tribot.api2007.Interfaces;
 
 public class TeleportConstants {
+    
+    private static int  WILD_LVL_MASTER = 90,
+                        WILD_LVL_CHILD = 46;
 
     public static final TeleportLimit
-            LEVEL_20_WILDERNESS_LIMIT = () -> Combat.getWildernessLevel() < 20,
-            LEVEL_30_WILDERNESS_LIMIT = () -> Combat.getWildernessLevel() < 30;
+            LEVEL_20_WILDERNESS_LIMIT = () -> getWildernessLevel() < 20,
+            LEVEL_30_WILDERNESS_LIMIT = () ->  getWildernessLevel() < 30;
+    
+    private static int getWildernessLevel(){
+        try{
+			RSInterface level = Interfaces.get(WILD_LVL_MASTER, WILD_LVL_CHILD);
+			if(level == null)
+				return 0;
+			String txt = level.getText();
+			if(txt == null)
+				return 0;
+			return Integer.parseInt(Utilities.extractNumber(txt));
+		} catch(Exception e){
+			return 0;
+		}
+    }
 
 }

--- a/webwalker_logic/teleport_logic/TeleportMethod.java
+++ b/webwalker_logic/teleport_logic/TeleportMethod.java
@@ -36,8 +36,10 @@ public enum TeleportMethod implements Validatable {
     ;
 
     private TeleportLocation[] destinations;
+    private TeleportLimit limit;
 
     TeleportMethod(TeleportLimit teleportLimit, TeleportLocation... destinations){
+        this.teleportLimit = teleportLimit;
         this.destinations = destinations;
     }
 
@@ -53,9 +55,14 @@ public enum TeleportMethod implements Validatable {
     public TeleportLocation[] getDestinations() {
         return destinations;
     }
+    public TeleportLimit getLimit(){
+        return limit;
+    }
 
     @Override
     public boolean canUse() {
+        if(!limit.canUse())
+            return false;
         switch (this){
             case ECTOPHIAL: return Inventory.find(Filters.Items.nameContains("Ectophial")).length > 0;
             case VARROCK_TELEPORT: return Spell.VARROCK_TELEPORT.canUse() || Inventory.getCount("Varrock teleport") > 0;


### PR DESCRIPTION
Cached the TeleportLimit in TeleportMethod, and check it in the TeleportMethod.canUse method
Added workaround for broken Combat.getWildernessLevel

