### PR TITLE
Fixed Motherload Mine Teleport, and fixed some interaction issues.

### DIFF
--- a/dax_api/teleport_logic/TeleportMethod.java
+++ b/dax_api/teleport_logic/TeleportMethod.java
@@ -149,7 +149,7 @@ public enum TeleportMethod implements Validatable {
             case FISHING_GUILD:
                 return teleportWithItem(SKILLS_FILTER, "Fishing.*");
             case MOTHERLOAD_MINE:
-                return teleportWithItem(SKILLS_FILTER, "Mother.*");
+                return teleportWithItem(SKILLS_FILTER, "Mining.*");
             case CRAFTING_GUILD:
                 return teleportWithItem(SKILLS_FILTER, "Crafting.*");
             case COOKING_GUILD:

--- a/dax_api/walker_engine/interaction_handling/PathObjectHandler.java
+++ b/dax_api/walker_engine/interaction_handling/PathObjectHandler.java
@@ -30,7 +30,7 @@ public class PathObjectHandler implements Loggable {
                 "Walk-Across", "Go-through", "Walk-across", "Climb", "Climb-up", "Climb-down", "Climb-over", "Climb over", "Climb-into", "Climb-through",
                 "Board", "Jump-from", "Jump-across", "Jump-to", "Squeeze-through", "Jump-over", "Pay-toll(10gp)", "Step-over", "Walk-down", "Walk-up", "Travel", "Get in",
                 "Investigate", "Operate"));
-        sortedBlackList = new TreeSet<>(Arrays.asList("Coffin"));
+        sortedBlackList = new TreeSet<>(Arrays.asList("Coffin", "null"));
         sortedBlackListOptions = new TreeSet<>(Arrays.asList("Chop down"));
         sortedHighPriorityOptions = new TreeSet<>(Arrays.asList("Pay-toll(10gp)"));
     }


### PR DESCRIPTION
Motherload mine teleport is called "Mining Guild" on skills necklace.
Sometimes there is an object in the way, with the name "null" but it contains interactive actions such as open so it attempts to interact with them.