### PR TITLE
Fixed Reachable issues

### DIFF
--- a/dax_api/walker_engine/interaction_handling/DoomsToggle.java
+++ b/dax_api/walker_engine/interaction_handling/DoomsToggle.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 
 public class DoomsToggle implements Loggable {
 
-    private static final int STRONGHOLD_TOGGLE = 579, WILDERNESS_TOGGLE = 475, SHANTY_TOGGLE = 565, WATERBIRTH = 574;
+    private static final int STRONGHOLD_TOGGLE = 579, WILDERNESS_TOGGLE = 475, SHANTY_TOGGLE = 565, WATERBIRTH = 574, LUMBRIDGE_SWAMP = 572;
 
-    private static final int[] GENERAL_CASES = {STRONGHOLD_TOGGLE, WILDERNESS_TOGGLE, SHANTY_TOGGLE, WATERBIRTH};
+    private static final int[] GENERAL_CASES = {STRONGHOLD_TOGGLE, WILDERNESS_TOGGLE, SHANTY_TOGGLE, WATERBIRTH, LUMBRIDGE_SWAMP};
 
     private static DoomsToggle instance;
 

--- a/dax_api/walker_engine/interaction_handling/PathObjectHandler.java
+++ b/dax_api/walker_engine/interaction_handling/PathObjectHandler.java
@@ -453,7 +453,8 @@ public class PathObjectHandler implements Loggable {
                 "No way! I'm reporting you to Jagex!",
                 "Talk to any banker in RuneScape.",
                 "Secure my device and reset my RuneScape password.",
-                "Don't share your information and report the player.");
+                "Don't share your information and report the player.",
+                "Decline the offer and report that player.");
     }
 
     private static boolean isClosedTrapDoor(RSObject object, String[] options){

--- a/dax_api/walker_engine/interaction_handling/PathObjectHandler.java
+++ b/dax_api/walker_engine/interaction_handling/PathObjectHandler.java
@@ -454,7 +454,8 @@ public class PathObjectHandler implements Loggable {
                 "Talk to any banker in RuneScape.",
                 "Secure my device and reset my RuneScape password.",
                 "Don't share your information and report the player.",
-                "Decline the offer and report that player.");
+                "Decline the offer and report that player.",
+                "Only on the Old School RuneScape website.");
     }
 
     private static boolean isClosedTrapDoor(RSObject object, String[] options){

--- a/dax_api/walker_engine/local_pathfinding/Reachable.java
+++ b/dax_api/walker_engine/local_pathfinding/Reachable.java
@@ -34,7 +34,7 @@ public class Reachable {
     }
 
     public boolean canReach(int x, int y){
-        RSTile playerPosition = Player.getPosition();
+        RSTile playerPosition = Player.getPosition().toLocalTile();
         if (playerPosition.getX() == x && playerPosition.getY() == y){
             return true;
         }
@@ -125,7 +125,6 @@ public class Reachable {
         if (map[x][y] == null){
             return null;
         }
-        int length = 0;
         RSTile tile = new RSTile(x, y, Player.getPosition().getPlane(), RSTile.TYPES.LOCAL);
         while ((tile = map[tile.getX()][tile.getY()]) != null){
             path.add(tile.toWorldTile());
@@ -302,7 +301,11 @@ public class Reachable {
         }
 
         public boolean isValidDirection(int x, int y, int[][] collisionData){
+        	
             try {
+                if (!AStarNode.isWalkable(collisionData[x + this.x][y + this.y])){
+                    return false;
+                }
                 switch (this) {
                     case NORTH:
                         return !AStarNode.blockedNorth(collisionData[x][y]);
@@ -330,7 +333,7 @@ public class Reachable {
                         }
                         return true;
                     case NORTH_WEST:
-                        if (AStarNode.blockedNorth(collisionData[x][y]) || AStarNode.blockedEast(collisionData[x][y])){
+                        if (AStarNode.blockedNorth(collisionData[x][y]) || AStarNode.blockedWest(collisionData[x][y])){
                             return false;
                         }
                         if (!AStarNode.isWalkable(collisionData[x - 1][y])){
@@ -347,7 +350,7 @@ public class Reachable {
                         }
                         return true;
                     case SOUTH_EAST:
-                        if (AStarNode.blockedNorth(collisionData[x][y]) || AStarNode.blockedEast(collisionData[x][y])){
+                        if (AStarNode.blockedSouth(collisionData[x][y]) || AStarNode.blockedEast(collisionData[x][y])){
                             return false;
                         }
                         if (!AStarNode.isWalkable(collisionData[x + 1][y])){
@@ -364,7 +367,7 @@ public class Reachable {
                         }
                         return true;
                     case SOUTH_WEST:
-                        if (AStarNode.blockedNorth(collisionData[x][y]) || AStarNode.blockedEast(collisionData[x][y])){
+                        if (AStarNode.blockedSouth(collisionData[x][y]) || AStarNode.blockedWest(collisionData[x][y])){
                             return false;
                         }
                         if (!AStarNode.isWalkable(collisionData[x - 1][y])){

--- a/dax_api/walker_engine/local_pathfinding/Reachable.java
+++ b/dax_api/walker_engine/local_pathfinding/Reachable.java
@@ -35,10 +35,10 @@ public class Reachable {
 
     public boolean canReach(int x, int y){
         RSTile playerPosition = Player.getPosition().toLocalTile();
-        if (playerPosition.getX() == x && playerPosition.getY() == y){
+        RSTile position = convertToLocal(x, y);
+        if (playerPosition.equals(position)){
             return true;
         }
-        RSTile position = convertToLocal(x, y);
         return getParent(position) != null;
     }
 


### PR DESCRIPTION
Previously, reachable would say some tiles were walkable when they weren't (see Reachable line 306 for the fix for this), and it would also say some tiles were not walkable when they actually were (lines 336, 353, 370 fix this).
Note that there is potential to perform a very minor optimization, as currently AStarNode#isWalkable will be called on each tile twice (once when checking if the direction is valid, and once after adding it to the queue). The check after adding to the queue might actually not be needed any longer, but I haven't looked into the side effects of removing it.