### PR TITLE
Change from abstract to a functional interface

### DIFF
--- a/scripts/dax_api/api_lib/models/DaxCredentialsProvider.java
+++ b/scripts/dax_api/api_lib/models/DaxCredentialsProvider.java
@@ -1,7 +1,6 @@
 package scripts.dax_api.api_lib.models;
 
-public abstract class DaxCredentialsProvider {
-
-    public abstract DaxCredentials getDaxCredentials();
-
+@FunctionalInterface
+public interface DaxCredentialsProvider {
+    DaxCredentials getDaxCredentials();
 }


### PR DESCRIPTION
Allows people using the API to use a lambda expression to set the credentials. It should be a safe change.

Example:
DaxWalker.setCredentials(() -> new DaxCredentials("YOUR-PUBLIC-KEY", "YOUR-SECRET-KEY"));