### PR TITLE
Burning amulet teleport limit

### DIFF
--- a/src/main/java/dax/teleports/Teleport.java
+++ b/src/main/java/dax/teleports/Teleport.java
@@ -319,6 +319,7 @@ public enum Teleport {
 		() -> teleportWithScrollInterface(WearableItemTeleport.SKILLS_FILTER, ".*Farming.*"),
 		TeleportConstants.LEVEL_30_WILDERNESS_LIMIT
 	),
+	
 	BURNING_AMULET_CHAOS_TEMPLE (
 		35, new RSTile(3236, 3635, 0),
 		() -> inMembersWorld() && WearableItemTeleport.has(WearableItemTeleport.BURNING_AMULET_FILTER),

--- a/src/main/java/dax/teleports/Teleport.java
+++ b/src/main/java/dax/teleports/Teleport.java
@@ -322,22 +322,19 @@ public enum Teleport {
 	BURNING_AMULET_CHAOS_TEMPLE (
 		35, new RSTile(3236, 3635, 0),
 		() -> inMembersWorld() && WearableItemTeleport.has(WearableItemTeleport.BURNING_AMULET_FILTER),
-		() -> WearableItemTeleport.teleport(WearableItemTeleport.BURNING_AMULET_FILTER, "(Chaos.*|Okay, teleport to level.*)"),
-		TeleportConstants.LEVEL_30_WILDERNESS_LIMIT
+		() -> WearableItemTeleport.teleport(WearableItemTeleport.BURNING_AMULET_FILTER, "(Chaos.*|Okay, teleport to level.*)")
 	),
 
 	BURNING_AMULET_BANDIT_CAMP (
 		35, new RSTile(3039, 3652, 0),
 		() -> inMembersWorld() && WearableItemTeleport.has(WearableItemTeleport.BURNING_AMULET_FILTER),
-		() -> WearableItemTeleport.teleport(WearableItemTeleport.BURNING_AMULET_FILTER, "(Bandit.*|Okay, teleport to level.*)"),
-		TeleportConstants.LEVEL_30_WILDERNESS_LIMIT
+		() -> WearableItemTeleport.teleport(WearableItemTeleport.BURNING_AMULET_FILTER, "(Bandit.*|Okay, teleport to level.*)")
 	),
 
 	BURNING_AMULET_LAVA_MAZE (
 		35, new RSTile(3029, 3843, 0),
 		() -> inMembersWorld() && WearableItemTeleport.has(WearableItemTeleport.BURNING_AMULET_FILTER),
-		() -> WearableItemTeleport.teleport(WearableItemTeleport.BURNING_AMULET_FILTER, "(Lava.*|Okay, teleport to level.*)"),
-		TeleportConstants.LEVEL_30_WILDERNESS_LIMIT
+		() -> WearableItemTeleport.teleport(WearableItemTeleport.BURNING_AMULET_FILTER, "(Lava.*|Okay, teleport to level.*)")
 	),
 
 	DIGSITE_PENDANT (


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Wilderness#Member_teleportation_up_to_level_30_Wilderness

Burning amulet is not a part of this list, therefore should only be used up to level 20 wilderness