### PR TITLE
Fixed Charter.getCharterLocations

### DIFF
--- a/src/main/java/dax/walker_engine/navigation_utils/Charter.java
+++ b/src/main/java/dax/walker_engine/navigation_utils/Charter.java
@@ -53,14 +53,19 @@ public class Charter implements Loggable {
                 InteractionHelper.click(InteractionHelper.getRSNPC(Filters.NPCs.actionsEquals("Charter")), "Charter", () -> Interfaces.isInterfaceValid(CHARTER_INTERFACE_MASTER) ? WaitFor.Return.SUCCESS : WaitFor.Return.IGNORE);
     }
 
+    private static boolean isValidCharterInterface(RSInterface rsInterface) {
+        return rsInterface != null
+                && rsInterface.getModelID() == -1
+                && rsInterface.getTextureID() == -1
+                && rsInterface.getActions() != null
+                && rsInterface.getActions().length == 1
+                && !rsInterface.isHidden();
+    }
+
     private static HashMap<LocationProperty, Location> getCharterLocations(){
         HashMap<LocationProperty, Location> locations = new HashMap<>();
-        InterfaceHelper.getAllInterfaces(CHARTER_INTERFACE_MASTER).stream().filter(
-
-                rsInterface -> rsInterface != null
-                && rsInterface.getModelID() == 17360
-                && !rsInterface.isHidden())
-
+        InterfaceHelper.getAllInterfaces(CHARTER_INTERFACE_MASTER).stream()
+                .filter(Charter::isValidCharterInterface)
                 .collect(Collectors.toList())
                 .forEach(rsInterface -> {
                     String[] actions = rsInterface.getActions();


### PR DESCRIPTION
Running this filter locally in tribot returns the correct charter locations again:

<img width="905" height="753" alt="image" src="https://github.com/user-attachments/assets/7bdc4700-b9ab-43ea-843d-02abf38dd0ea" />